### PR TITLE
Prevent flickering of top navigation menu on hover

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -55,9 +55,12 @@ a {
   font-size: 21px;
 }
 
+.hover{
+   padding: 10px 10px;
+}
+
 .hover:hover {
   background-color: rgb(173, 26, 26);
-  padding: 10px 10px;
   border-radius: 10px;
   width: 15px;
 }

--- a/assets/style.css
+++ b/assets/style.css
@@ -55,8 +55,8 @@ a {
   font-size: 21px;
 }
 
-.hover{
-   padding: 10px 10px;
+.hover {
+  padding: 10px 10px;
 }
 
 .hover:hover {


### PR DESCRIPTION
Increasing padding on already rendered items on mouse hover will cause the browser to repaint, causing a flicker